### PR TITLE
Implemented submit card hookup and global user context

### DIFF
--- a/apps/frontend/src/components/Auth/UserUtils.tsx
+++ b/apps/frontend/src/components/Auth/UserUtils.tsx
@@ -1,0 +1,51 @@
+import { Auth } from "aws-amplify";
+import { UserSchema } from "src/schemas/UserSchema";
+
+// TODO: Below code is primarily pulled from backend files (User.client.ts and user.service.ts). This should be moved to a shared folder
+import { z } from "zod";
+import { UserTypes } from "../TimeCardPage/types";
+
+/**
+ * The client schema of a Cognito attribute.
+ * e.g : {Name: 'sub', 'value': 'aeddc72a-fe42b78a8-....'}
+ */
+export const CognitoAttributes = z.object({
+  email: z.string(),
+  given_name: z.string(),
+  family_name: z.string(),
+  sub: z.string(),
+});
+
+/**
+ * Represents the client schema of a User object returned from Cognito.
+ */
+export const CognitoUser = z.object({
+  attributes: CognitoAttributes, // TODO : should likely expand this out to include all the known attributes we expect from cognito
+  username: z.string(),
+});
+
+export type CognitoUser = z.infer<typeof CognitoUser>;
+
+const convertCognitoUser = function (user: CognitoUser): UserSchema {
+  var sub = user.attributes.sub;
+  var firstName = user.attributes.given_name;
+  var lastName = user.attributes.family_name;
+
+  // TODO: The type here shouldn't be hard-coded
+
+  return {
+    FirstName: firstName,
+    LastName: lastName,
+    UserID: sub,
+    Type: UserTypes.Supervisor,
+  };
+};
+
+// TODO: Should this be in a separate file because
+export const getCurrentUser = async function (): Promise<UserSchema> {
+  const cognitoCurrentUser = await Auth.currentUserInfo();
+  console.log(cognitoCurrentUser);
+  const currUser = CognitoUser.parse(cognitoCurrentUser);
+  //TODO: Also make a call to apiClient.getUser() to get the group for this user
+  return convertCognitoUser(currUser);
+};

--- a/apps/frontend/src/components/Auth/UserUtils.tsx
+++ b/apps/frontend/src/components/Auth/UserUtils.tsx
@@ -41,7 +41,6 @@ const convertCognitoUser = function (user: CognitoUser): UserSchema {
   };
 };
 
-// TODO: Should this be in a separate file because
 export const getCurrentUser = async function (): Promise<UserSchema> {
   const cognitoCurrentUser = await Auth.currentUserInfo();
   console.log(cognitoCurrentUser);

--- a/apps/frontend/src/components/Auth/apiClient.tsx
+++ b/apps/frontend/src/components/Auth/apiClient.tsx
@@ -2,7 +2,7 @@ import { Auth } from "aws-amplify";
 import axios, { AxiosInstance } from "axios";
 import { TimeSheetSchema } from "../../schemas/TimesheetSchema";
 import { UserSchema } from "../../schemas/UserSchema";
-import { ReportOptions } from "../TimeCardPage/types";
+import { ReportOptions, UserTypes } from "../TimeCardPage/types";
 
 const defaultBaseUrl =
   process.env.REACT_APP_API_BASE_URL ?? "http://localhost:3000";
@@ -67,7 +67,7 @@ export class ApiClient {
   }
 
   public async updateTimesheet(req): Promise<unknown> {
-    return this.axiosInstance.post('/auth/timesheet', req)
+    return this.axiosInstance.post("/auth/timesheet", req);
   }
 
   // TODO: setup endpoint for associate/supervisor/admin so it returns a list of timesheets for given uuid
@@ -93,8 +93,9 @@ export class ApiClient {
       UserID: "abc",
       FirstName: "john",
       LastName: "doe",
-      Type: "Admin",
-      Picture: "https://imgs.search.brave.com/DZmzoTAPlNT9HUb2ISfyTd_sPZab1hG4VcyupoK2gwE/rs:fit:860:0:0/g:ce/aHR0cHM6Ly90My5m/dGNkbi5uZXQvanBn/LzAwLzYxLzU0LzA4/LzM2MF9GXzYxNTQw/ODU1X3lFYmIwTlRr/d3ZJVzdaZG1KeThM/aHU1WHJPMXlweURl/LmpwZw",
+      Type: UserTypes.Admin,
+      Picture:
+        "https://imgs.search.brave.com/DZmzoTAPlNT9HUb2ISfyTd_sPZab1hG4VcyupoK2gwE/rs:fit:860:0:0/g:ce/aHR0cHM6Ly90My5m/dGNkbi5uZXQvanBn/LzAwLzYxLzU0LzA4/LzM2MF9GXzYxNTQw/ODU1X3lFYmIwTlRr/d3ZJVzdaZG1KeThM/aHU1WHJPMXlweURl/LmpwZw",
     };
   }
 
@@ -105,21 +106,26 @@ export class ApiClient {
         UserID: "bcd",
         FirstName: "joe",
         LastName: "jane",
-        Type: "Associate",
+        Type: UserTypes.Associate,
         Picture: "https://www.google.com/panda.png",
       },
     ];
   }
 
   //TODO: hook up to backend
-  public async saveComment(comment: string, timesheetID: number): Promise<Boolean> {
+  public async saveComment(
+    comment: string,
+    timesheetID: number
+  ): Promise<Boolean> {
     return true;
   }
 
   //TODO: hook up to backend
-  public async saveReport(report: ReportOptions, timesheetID: number): Promise<Boolean> {
+  public async saveReport(
+    report: ReportOptions,
+    timesheetID: number
+  ): Promise<Boolean> {
     return true;
   }
-
 }
 export default new ApiClient();

--- a/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
+++ b/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
@@ -1,61 +1,216 @@
-import React, { useState, useEffect } from 'react'
-import { WeeklyCommentModal } from './CommentModal';
-import { Box, Card, CardHeader, CardBody, CardFooter, Button } from '@chakra-ui/react';
-import { CardState } from './types'
-import { CommentSchema } from 'src/schemas/RowSchema';
+import { CardState } from "./types";
 
-interface SubmitCardProps {
-    setWeeklyComments: Function;
-    setWeeklyReports: Function;
-    weeklyComments: CommentSchema[];
-    weeklyReports: CommentSchema[];
+import React, { useState, useEffect, useContext } from "react";
+import { Box, Card, CardBody, CardFooter, Button } from "@chakra-ui/react";
+import { DEFAULT_COLORS } from "src/constants";
+import ApiClient from "src/components/Auth/apiClient";
+import * as updateSchemas from "src/schemas/backend/UpdateTimesheet";
+import { StatusType, StatusEntryType } from "src/schemas/StatusSchema";
+import { UserTypes } from "./types";
+import moment from "moment";
+import { useToast } from "@chakra-ui/react";
+import { UserContext } from "./UserContext";
+import { TimesheetStatus } from "src/schemas/TimesheetSchema";
+
+interface submitCardProps {
+  timesheetId: number;
+  associateId: string;
+  timesheetStatus: StatusType;
+  refreshTimesheetCallback: Function;
 }
 
-export default function SubmitCard({
-    setWeeklyComments,
-    setWeeklyReports,
-    weeklyComments,
-    weeklyReports
-}: SubmitCardProps) {
+export default function SubmitCard(props: submitCardProps) {
+  const toast = useToast();
+  const currUser = useContext(UserContext);
 
+  /** Whether or not the logged-in user has submitted this timesheet yet.*/
   const [submitted, setSubmitted] = useState(false);
+
+  /** The date and time (as a moment) that the logged-in user submitted/reviewed/finalized this timesheet.*/
   const [submitDate, setSubmitDate] = useState(null);
+
+  /**
+   *   The card state which corresponds to the latest status update from the timesheet. Corresponds to card color.
+   *   Note that this is *not* dependent on the logged in user. I.e. if the latest status update was that
+   *   the supervisor had submitted their timesheet review, the card state would be CardState.InReviewAdmin for
+   *   any associate, supervisor, or admin that was viewing the timesheet.
+   */
   const [state, setState] = useState(CardState.Unsubmitted);
 
+  // Run whenever there's an update to the current logged in user (i.e. re-render the correct submission status for the user type)
   useEffect(() => {
-    //TODO - API Call to determine if the table has been submitted or not.
-    //Will set submitted? here and also submitDate if it was submitted to grab the date     
-  }, [])
-
-  const submitAction = () => {
-    setSubmitted(!submitted);
-    const currentTime = new Date();
-    setSubmitDate(currentTime.toString());
-    if (state === CardState.Unsubmitted) {
-      setState(CardState.InReviewEmployer);
+    if (currUser === undefined) {
+      return;
     }
-    else {
+
+    let statusEntry: StatusEntryType = undefined;
+
+    // Determine the appropriate status entry to match up with the logged in user's role
+    switch (currUser.Type) {
+      case UserTypes.Associate:
+        statusEntry = props.timesheetStatus.HoursSubmitted;
+        break;
+
+      case UserTypes.Supervisor:
+        statusEntry = props.timesheetStatus.HoursReviewed;
+        break;
+
+      case UserTypes.Admin:
+        statusEntry = props.timesheetStatus.Finalized;
+        break;
+    }
+
+    const isSubmitted = statusEntry !== undefined;
+    setSubmitted(isSubmitted);
+
+    // Set the submitted date to when the corresponding status entry was logged for the user type
+    if (isSubmitted && statusEntry.Date !== undefined) {
+      setSubmitDate(moment.unix(statusEntry.Date));
+    }
+
+    // Determine the latest status update to set the card state
+    if (props.timesheetStatus.Finalized !== undefined) {
+      setState(CardState.AdminFinalized);
+    } else if (props.timesheetStatus.HoursReviewed !== undefined) {
+      setState(CardState.InReviewAdmin);
+    } else if (props.timesheetStatus.HoursSubmitted !== undefined) {
+      setState(CardState.InReviewSupervisor);
+    } else {
       setState(CardState.Unsubmitted);
     }
-  }
+  }, [currUser, props.timesheetStatus]);
+
+  const submitAction = async () => {
+    console.log("Current user id:", currUser.UserID);
+    let statusSubmissionType: string;
+
+    // Determine the appropriate status entry to match up with the logged in user's role
+    switch (currUser.Type) {
+      case UserTypes.Associate:
+        statusSubmissionType = TimesheetStatus.HOURS_SUBMITTED;
+        break;
+
+      case UserTypes.Supervisor:
+        statusSubmissionType = TimesheetStatus.HOURS_REVIEWED;
+        break;
+
+      case UserTypes.Admin:
+        statusSubmissionType = TimesheetStatus.HOURS_SUBMITTED;
+        break;
+    }
+
+    // Update the current timesheet to be submitted by the logged-in user.
+    // The type of status can be determined on the backend by the user type
+    try {
+      const response = await ApiClient.updateTimesheet(
+        updateSchemas.TimesheetUpdateRequest.parse({
+          TimesheetID: props.timesheetId,
+          Operation: updateSchemas.TimesheetOperations.STATUS_CHANGE,
+          Payload: updateSchemas.StatusChangeRequest.parse({
+            TimesheetId: props.timesheetId,
+            AssociateId: props.associateId,
+            authorId: currUser.UserID, // TODO: Implement authorId functionality instead of dummy data
+            statusType: statusSubmissionType,
+            dateSubmitted: moment().unix(),
+          }),
+        })
+      );
+
+      // TODO: Confirm successful 2xx code responSse from API
+      props.refreshTimesheetCallback();
+
+      toast({
+        title: "Successful submission!",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      console.log(err);
+      toast({
+        title: "Uh oh, something went wrong...",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+  };
 
   return (
-    <Box className="col-md-2" style={{ display: "flex", justifyContent: 'flex-end' }}>
+    <Box
+      className="col-md-2"
+      style={{ display: "flex", justifyContent: "flex-end" }}
+    >
       <Card
-        bg={(state === CardState.Completed) ? 'success' : ((state === CardState.InReviewBreaktime || state === CardState.InReviewEmployer) ? 'warning' : 'danger')}
-        textColor="white"
+        bg={
+          state === CardState.AdminFinalized
+            ? "success"
+            : state === CardState.InReviewAdmin ||
+              state === CardState.InReviewSupervisor
+            ? "warning"
+            : "danger"
+        }
+        textColor={DEFAULT_COLORS.BREAKTIME_BLUE}
         key="submit_description"
-        className="mb-2 text-center">
+        className="mb-2 text-center"
+      >
         <CardBody>
-          <Button variant={'light'} onClick={submitAction}>{submitted ? "Resubmit" : "Submit!"}</Button>
+          <Button onClick={submitAction}>
+            {submitted ? "Resubmit" : "Submit!"}
+          </Button>
         </CardBody>
-        {submitted && <CardFooter>
-          {submitDate}
-          {state}
-          <WeeklyCommentModal setWeeklyComments={setWeeklyComments} setWeeklyReports={setWeeklyReports} weeklyComments={weeklyComments} weeklyReports={weeklyReports}/>
-        </CardFooter>}
-      </Card>
-    </Box >
-  );
+        {submitted && (
+          <CardFooter>
+            {/* TODO: The AuthorIDs below should all be replaced with calls to the API and then have a User profile card there instead (or at least the name, rather than ID lol) */}
+            <div>
+              {props.timesheetStatus.HoursSubmitted &&
+              props.timesheetStatus.HoursSubmitted.Date ? (
+                <p>
+                  Associate: {props.timesheetStatus.HoursSubmitted.AuthorID},{" "}
+                  <br />
+                  Submitted on:{" "}
+                  {customDateFormat(props.timesheetStatus.HoursSubmitted.Date)}
+                </p>
+              ) : (
+                <p>Associate: Unsubmitted</p>
+              )}
 
+              {props.timesheetStatus.HoursReviewed &&
+              props.timesheetStatus.HoursReviewed.Date ? (
+                <p>
+                  Supervsior: {props.timesheetStatus.HoursReviewed.AuthorID},{" "}
+                  <br />
+                  Submitted on:{" "}
+                  {customDateFormat(props.timesheetStatus.HoursReviewed.Date)}
+                </p>
+              ) : (
+                <p>Supervisor: Unsubmitted</p>
+              )}
+
+              {props.timesheetStatus.Finalized &&
+              props.timesheetStatus.Finalized.Date ? (
+                <p>
+                  Admin: {props.timesheetStatus.Finalized.AuthorID}, <br />
+                  Submitted on:{" "}
+                  {customDateFormat(props.timesheetStatus.Finalized.Date)}
+                </p>
+              ) : (
+                <p>Admin: Unsubmitted</p>
+              )}
+            </div>
+          </CardFooter>
+        )}
+      </Card>
+    </Box>
+  );
+}
+
+function customDateFormat(date) {
+  const dateX = new Date(date * 1000);
+  return dateX.toLocaleDateString("en-US", {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+  });
 }

--- a/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
+++ b/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
@@ -204,11 +204,7 @@ export default function SubmitCard(props: submitCardProps) {
   );
 }
 
-function customDateFormat(date) {
-  const dateX = new Date(date * 1000);
-  return dateX.toLocaleDateString("en-US", {
-    year: "2-digit",
-    month: "2-digit",
-    day: "2-digit",
-  });
+/** Standardized moment.format() wrapper for epoch to string timestamps */
+function customDateFormat(date: number): string {
+  return moment.unix(date).format("MM/DD/YYYY HH:mm");
 }

--- a/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
+++ b/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
@@ -78,7 +78,7 @@ export default function SubmitCard(props: submitCardProps) {
     } else {
       setState(CardState.Unsubmitted);
     }
-  }, [currUser, props.timesheetStatus]);
+  }, [currUser, props.timesheetStatus, props.timesheetId]);
 
   const submitAction = async () => {
     console.log("Current user id:", currUser.UserID);
@@ -160,7 +160,6 @@ export default function SubmitCard(props: submitCardProps) {
             {submitted ? "Resubmit" : "Submit!"}
           </Button>
         </CardBody>
-        {submitted && (
           <CardFooter>
             {/* TODO: The AuthorIDs below should all be replaced with calls to the API and then have a User profile card there instead (or at least the name, rather than ID lol) */}
             <div>
@@ -200,7 +199,6 @@ export default function SubmitCard(props: submitCardProps) {
               )}
             </div>
           </CardFooter>
-        )}
       </Card>
     </Box>
   );

--- a/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
+++ b/apps/frontend/src/components/TimeCardPage/SubmitCard.tsx
@@ -9,6 +9,7 @@ import moment from "moment";
 import { useToast } from "@chakra-ui/react";
 import { UserContext } from "./UserContext";
 import { TimesheetStatus } from "src/schemas/TimesheetSchema";
+import { createToast } from "./utils";
 
 interface submitCardProps {
   timesheetId: number;
@@ -23,9 +24,6 @@ export default function SubmitCard(props: submitCardProps) {
 
   /** Whether or not the logged-in user has submitted this timesheet yet.*/
   const [timesheetSubmitted, setTimesheetSubmitted] = useState(false);
-
-  /** The date and time (as a moment) that the logged-in user submitted/reviewed/finalized this timesheet.*/
-  const [submitDate, setSubmitDate] = useState(null);
 
   /**
    *   The card state which corresponds to the latest status update from the timesheet. Corresponds to card color.
@@ -60,11 +58,6 @@ export default function SubmitCard(props: submitCardProps) {
 
     const isSubmitted = statusEntry !== undefined;
     setTimesheetSubmitted(isSubmitted);
-
-    // Set the submitted date to when the corresponding status entry was logged for the user type
-    if (isSubmitted && statusEntry.Date !== undefined) {
-      setSubmitDate(moment.unix(statusEntry.Date));
-    }
 
     // Determine the latest status update to set the card state
     if (props.timesheetStatus.Finalized !== undefined) {
@@ -119,20 +112,24 @@ export default function SubmitCard(props: submitCardProps) {
       // TODO: Confirm successful 2xx code responSse from API
       props.refreshTimesheetCallback();
 
-      toast({
-        title: "Successful submission!",
-        status: "success",
-        duration: 3000,
-        isClosable: true,
-      });
+      toast(
+        createToast({
+          title: "Successful submission!",
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        })
+      );
     } catch (err) {
       console.log(err);
-      toast({
-        title: "Uh oh, something went wrong...",
-        status: "error",
-        duration: 3000,
-        isClosable: true,
-      });
+      toast(
+        createToast({
+          title: "Uh oh, something went wrong...",
+          status: "error",
+          duration: 3000,
+          isClosable: true,
+        })
+      );
       return;
     }
   };

--- a/apps/frontend/src/components/TimeCardPage/TimeSheet.tsx
+++ b/apps/frontend/src/components/TimeCardPage/TimeSheet.tsx
@@ -29,7 +29,7 @@ import {
 
 import { TIMESHEET_DURATION, TIMEZONE } from "src/constants";
 
-import { Review_Stages, TABLE_COLUMNS, CommentType } from "./types";
+import { TABLE_COLUMNS, CommentType } from "./types";
 import moment, { Moment } from "moment-timezone";
 
 import apiClient from "../Auth/apiClient";

--- a/apps/frontend/src/components/TimeCardPage/TimeSheet.tsx
+++ b/apps/frontend/src/components/TimeCardPage/TimeSheet.tsx
@@ -1,341 +1,415 @@
-import React, {useState, useMemo} from 'react';
-import TimeTable from './TimeTable'
-import {useEffect} from 'react';
-import SubmitCard from './SubmitCard';
-import DateSelectorCard from './SelectWeekCard';
-import {UserContext} from './UserContext';
+import React, { useState, useMemo } from "react";
+import TimeTable from "./TimeTable";
+import { useEffect } from "react";
+import SubmitCard from "./SubmitCard";
+import DateSelectorCard from "./SelectWeekCard";
+import { UserContext } from "./UserContext";
+import { getCurrentUser } from "../Auth/UserUtils";
 
 import {
-    Alert,
-    AlertIcon,
-    AlertTitle,
-    AlertDescription,
-    Box,
-    IconButton,
-    Card,
-    CardBody,
-    Avatar,
-    Flex,
-    Text,
-    Tabs,
-    TabList,
-    Tab,
-    Spacer,
-    HStack,
-    VStack,
-    ButtonGroup
-} from '@chakra-ui/react'
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
+  Box,
+  IconButton,
+  Card,
+  CardBody,
+  Avatar,
+  Flex,
+  Text,
+  Tabs,
+  TabList,
+  Tab,
+  Spacer,
+  HStack,
+  VStack,
+  ButtonGroup,
+} from "@chakra-ui/react";
 
+import { TIMESHEET_DURATION, TIMEZONE } from "src/constants";
 
-import {TIMESHEET_DURATION, TIMEZONE} from 'src/constants';
+import { Review_Stages, TABLE_COLUMNS, CommentType } from "./types";
+import moment, { Moment } from "moment-timezone";
 
-import {Review_Stages, TABLE_COLUMNS, CommentType} from './types';
-import moment, {Moment} from 'moment-timezone';
+import apiClient from "../Auth/apiClient";
+import AggregationTable from "./AggregationTable";
+import { v4 as uuidv4 } from "uuid";
+import { UserSchema } from "../../schemas/UserSchema";
 
-import apiClient from '../Auth/apiClient';
-import AggregationTable from './AggregationTable';
-import {v4 as uuidv4} from 'uuid';
-import {UserSchema} from '../../schemas/UserSchema'
-
-import { SearchIcon, WarningIcon, DownloadIcon } from '@chakra-ui/icons';
-import { Select, components } from 'chakra-react-select'
-import { TimeSheetSchema } from 'src/schemas/TimesheetSchema';
-import { CommentSchema, RowSchema } from 'src/schemas/RowSchema';
-import { getAllActiveCommentsOfType } from './utils';
-import { Stack } from 'react-bootstrap';
-import { Divider } from '@aws-amplify/ui-react';
-
-
+import { SearchIcon, WarningIcon, DownloadIcon } from "@chakra-ui/icons";
+import { Select, components } from "chakra-react-select";
+import { TimeSheetSchema } from "src/schemas/TimesheetSchema";
+import { CommentSchema, RowSchema } from "src/schemas/RowSchema";
+import { getAllActiveCommentsOfType } from "./utils";
+import { Stack } from "react-bootstrap";
+import { Divider } from "@aws-amplify/ui-react";
 
 // Always adjust local timezone to Breaktime's timezone
 moment.tz.setDefault(TIMEZONE);
 
 const testingEmployees = [
-    {
-        UserID: "abc",
-        FirstName: "joe",
-        LastName: "jane",
-        Type: "Employee",
-        Picture: "https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg"
-    },
-    {
-        UserID: "bcd",
-        FirstName: "david",
-        LastName: "lev",
-        Type: "Employee",
-        Picture: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/Grosser_Panda.JPG/1200px-Grosser_Panda.JPG"
-    },
-    {
-        UserID: "cde",
-        FirstName: "crys",
-        LastName: "tal",
-        Type: "Employee",
-        Picture: "https://www.google.com/capybara.png"
-    },
-    {UserID: "def", FirstName: "ken", LastName: "ney", Type: "Employee", Picture: "https://www.google.com/koala.png"},
-]
+  {
+    UserID: "abc",
+    FirstName: "joe",
+    LastName: "jane",
+    Type: "Employee",
+    Picture:
+      "https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg",
+  },
+  {
+    UserID: "bcd",
+    FirstName: "david",
+    LastName: "lev",
+    Type: "Employee",
+    Picture:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/Grosser_Panda.JPG/1200px-Grosser_Panda.JPG",
+  },
+  {
+    UserID: "cde",
+    FirstName: "crys",
+    LastName: "tal",
+    Type: "Employee",
+    Picture: "https://www.google.com/capybara.png",
+  },
+  {
+    UserID: "def",
+    FirstName: "ken",
+    LastName: "ney",
+    Type: "Employee",
+    Picture: "https://www.google.com/koala.png",
+  },
+];
 
-function ProfileCard({employee}) {
-
-    return (
-        <Card direction="row" width="50%">
-            <Avatar src={employee?.Picture} name={employee?.FirstName + " " + employee?.LastName} size='md'
-                    showBorder={true} borderColor='black' borderWidth='thick'/>
-            <CardBody>
-                <Text>{employee?.FirstName + " " + employee?.LastName}</Text>
-            </CardBody>
-        </Card>
-    )
+function ProfileCard({ employee }) {
+  return (
+    <Card direction="row" width="50%">
+      <Avatar
+        src={employee?.Picture}
+        name={employee?.FirstName + " " + employee?.LastName}
+        size="md"
+        showBorder={true}
+        borderColor="black"
+        borderWidth="thick"
+      />
+      <CardBody>
+        <Text>{employee?.FirstName + " " + employee?.LastName}</Text>
+      </CardBody>
+    </Card>
+  );
 }
 
-function SearchEmployeeTimesheet({employees, setSelected}) {
+function SearchEmployeeTimesheet({ employees, setSelected }) {
+  const handleChange = (selectedOption) => {
+    setSelected(selectedOption);
+  };
 
-    const handleChange = (selectedOption) => {
-        setSelected(selectedOption);
-    }
+  const customStyles = {
+    control: (base) => ({
+      ...base,
+      flexDirection: "row-reverse",
+    }),
+  };
 
-    const customStyles = {
-        control: (base) => ({
-            ...base,
-            flexDirection: 'row-reverse',
-        }),
-    }
-
-    const DropdownIndicator = (props) => {
-        return (
-            <components.DropdownIndicator {...props}>
-                <SearchIcon/>
-            </components.DropdownIndicator>
-        );
-    };
-
-    // TODO: fix styling
-    // at the moment defaultValue is the first user in the employees array
-    // which is currently an invariant that matches the useState in Page
+  const DropdownIndicator = (props) => {
     return (
-        <div style={{width: '600px'}}>
-            <Select isSearchable={true}
-                    defaultValue={employees[0]}
-                    chakraStyles={customStyles}
-                    size="lg"
-                    options={employees}
-                    onChange={handleChange}
-                    components={{DropdownIndicator}}
-                    getOptionLabel={option => `${option.FirstName + " " + option.LastName}`}
-                    getOptionValue={option => `${option.FirstName + " " + option.LastName}`}/>
-        </div>
-    )
+      <components.DropdownIndicator {...props}>
+        <SearchIcon />
+      </components.DropdownIndicator>
+    );
+  };
+
+  // TODO: fix styling
+  // at the moment defaultValue is the first user in the employees array
+  // which is currently an invariant that matches the useState in Page
+  return (
+    <div style={{ width: "600px" }}>
+      <Select
+        isSearchable={true}
+        defaultValue={employees[0]}
+        chakraStyles={customStyles}
+        size="lg"
+        options={employees}
+        onChange={handleChange}
+        components={{ DropdownIndicator }}
+        getOptionLabel={(option) =>
+          `${option.FirstName + " " + option.LastName}`
+        }
+        getOptionValue={(option) =>
+          `${option.FirstName + " " + option.LastName}`
+        }
+      />
+    </div>
+  );
 }
 
 interface WeeklyCommentSectionProps {
-    weeklyComments: CommentSchema[];
-    weeklyReports: CommentSchema[];
+  weeklyComments: CommentSchema[];
+  weeklyReports: CommentSchema[];
 }
 
 // TODO: idk if we're keeping up just gonna remove bc doesnt look great atm
 function WeeklyCommentSection({
-                                  weeklyComments,
-                                  weeklyReports
-                              }: WeeklyCommentSectionProps) {
-    // row of Comments
-    // row of Reports
+  weeklyComments,
+  weeklyReports,
+}: WeeklyCommentSectionProps) {
+  // row of Comments
+  // row of Reports
 
-    // repetitive but readable code and should be more extensible
-    return (
+  // repetitive but readable code and should be more extensible
+  return (
+    <HStack>
+      <Text>Weekly Feedback</Text>
+      <Divider orientation="vertical" />
+      <Stack>
         <HStack>
-            <Text>Weekly Feedback</Text>
-            <Divider orientation='vertical'/>
-            <Stack>
-                <HStack>
-                    <Stack>
-                        {weeklyComments.map(
-                            (comment) => (
-                                <HStack>
-                                    {/* TODO: later replace w api call to get user from userID*/}
-                                    {/* also use display card once it gets merged in*/}
-                                    <ProfileCard employee={testingEmployees[0]}/>
-                                    <Text>{comment.Content}</Text>
-                                </HStack>
-                            ))}
-                    </Stack>
-                </HStack>
-                <Divider/>
-                <HStack>
-                    <Stack>
-                        {weeklyReports.map(
-                            (report) => (
-                                <HStack>
-                                    {/* TODO: later replace w api call to get user from userID*/}
-                                    <ProfileCard employee={testingEmployees[1]}/>
-                                    <Text>{report.Content}</Text>
-                                </HStack>
-                            ))}
-                    </Stack>
-                </HStack>
-            </Stack>
+          <Stack>
+            {weeklyComments.map((comment) => (
+              <HStack>
+                {/* TODO: later replace w api call to get user from userID*/}
+                {/* also use display card once it gets merged in*/}
+                <ProfileCard employee={testingEmployees[0]} />
+                <Text>{comment.Content}</Text>
+              </HStack>
+            ))}
+          </Stack>
         </HStack>
-    )
+        <Divider />
+        <HStack>
+          <Stack>
+            {weeklyReports.map((report) => (
+              <HStack>
+                {/* TODO: later replace w api call to get user from userID*/}
+                <ProfileCard employee={testingEmployees[1]} />
+                <Text>{report.Content}</Text>
+              </HStack>
+            ))}
+          </Stack>
+        </HStack>
+      </Stack>
+    </HStack>
+  );
 }
 
 export default function Page() {
-    //const today = moment();
-    const [selectedDate, setSelectedDate] = useState(moment().startOf('week').day(0));
+  //const today = moment();
+  const [selectedDate, setSelectedDate] = useState(
+    moment().startOf("week").day(0)
+  );
 
-    // fetch the information of the user whos timesheet is being displayed
-    // if user is an employee selected and user would be the same
-    // if user is a supervisor/admin then selected would contain the information of the user
-    // whos timesheet is being looked at and user would contain the supervisor/admins information
-    // by default the first user is selected
-    const [selectedUser, setSelectedUser] = useState<UserSchema>();
-    const [user, setUser] = useState<UserSchema>();
+  // fetch the information of the user whos timesheet is being displayed
+  // if user is an employee selected and user would be the same
+  // if user is a supervisor/admin then selected would contain the information of the user
+  // whos timesheet is being looked at and user would contain the supervisor/admins information
+  // by default the first user is selected
+  const [selectedUser, setSelectedUser] = useState<UserSchema>();
+  const [user, setUser] = useState<UserSchema>();
 
-    // associates is only used by supervisor/admin for the list of all associates they have access to
-    const [associates, setAssociates] = useState<UserSchema[]>([]);
+  // associates is only used by supervisor/admin for the list of all associates they have access to
+  const [associates, setAssociates] = useState<UserSchema[]>([]);
 
-    // A list of the timesheet objects
-    // TODO: add types
-    const [userTimesheets, setUserTimesheets] = useState([]);
-    const [currentTimesheets, setCurrentTimesheets] = useState([]);
-    const [selectedTimesheet, setTimesheet] = useState(undefined);
+  // A list of the timesheet objects
+  // TODO: add types
+  const [userTimesheets, setUserTimesheets] = useState([]);
+  const [currentTimesheets, setCurrentTimesheets] = useState([]);
+  const [selectedTimesheet, setTimesheet] = useState(undefined);
 
-    const [weeklyComments, setWeeklyComments] = useState<CommentSchema[]>([]);
-    const [weeklyReports, setWeeklyReports] = useState<CommentSchema[]>([]);
+  const [weeklyComments, setWeeklyComments] = useState<CommentSchema[]>([]);
+  const [weeklyReports, setWeeklyReports] = useState<CommentSchema[]>([]);
 
-    // this hook should always run first
-    useEffect(() => {
-        apiClient.getUser().then(userInfo => {
-            setUser(userInfo);
-            if (userInfo.Type === "Supervisor" || userInfo.Type === "Admin") {
-                apiClient.getAllUsers().then(users => {
-                    setAssociates(users);
-                    setSelectedUser(users[0]);
-                })
-            }
-            setSelectedUser(userInfo)
-        })
-        // if employee setSelectedUSer to be userinfo
-        // if supervisor/admin get all users
-        // set selected user
-    }, [])
+  // this hook should always run first
+  useEffect(() => {
+    // Get the current logged in user
+    getCurrentUser().then((currentUser) => {
+      console.log("Current user: ", currentUser);
+      setUser(currentUser);
+    });
 
-    // Pulls user timesheets, marking first returned as the active one
-    useEffect(() => {
-        apiClient.getUserTimesheets(selectedUser?.UserID).then(timesheets => {
-            setUserTimesheets(timesheets);
-            //By Default just render / select the first timesheet for now
-            setCurrentTimesheetsToDisplay(timesheets, selectedDate);
+    apiClient.getUser().then((userInfo) => {
+      if (userInfo.Type === "Supervisor" || userInfo.Type === "Admin") {
+        apiClient.getAllUsers().then((users) => {
+          setAssociates(users);
+          setSelectedUser(users[0]);
         });
-    }, [selectedUser])
+      }
+      setSelectedUser(userInfo);
+    });
+    // if employee setSelectedUSer to be userinfo
+    // if supervisor/admin get all users
+    // set selected user
+  }, []);
 
-    const processTimesheetChange = (updated_sheet) => {
-        // Updating the rows of the selected timesheets from our list of timesheets
-        const modifiedTimesheets = userTimesheets.map((entry) => {
-            if (entry.TimesheetID === selectedTimesheet.TimesheetID) {
-                return {
-                    ...entry,
-                    TableData: updated_sheet.TableData
-                }
-            }
-            return entry
-        });
-        setUserTimesheets(modifiedTimesheets);
+  const getUpdatedTimesheet = (userId) => {
+    apiClient.getUserTimesheets(userId).then((timesheets) => {
+      setUserTimesheets(timesheets);
+      //By Default just render / select the first timesheet for now
+      setCurrentTimesheetsToDisplay(timesheets, selectedDate);
+    });
+  };
 
-        //Also need to update our list of currently selected - TODO come up with a way to not need these duplicated lists
-        setCurrentTimesheets(currentTimesheets.map(
-            (entry) => {
-                if (entry.TimesheetID === selectedTimesheet.TimesheetID) {
-                    return {
-                        ...entry,
-                        TableData: updated_sheet.TableData
-                    }
-                }
-                return entry
-            }
-        ));
+  // Pulls user timesheets, marking first returned as the active one
+  useEffect(() => {
+    getUpdatedTimesheet(selectedUser?.UserID);
+  }, [selectedUser]);
+
+  // Callback function that triggers GET request to the API to grab the most recent version of timesheets for the current selected user,
+  // and re-sets the current timesheet state variable
+  const forceRefreshTimesheet = () => {
+    if (selectedUser !== undefined) {
+      getUpdatedTimesheet(selectedUser.UserID);
+    } else {
+      console.log("ERROR: Couldn't force refresh timesheet");
     }
+  };
 
-    const updateDateRange = (date: Moment) => {
-        setSelectedDate(date);
-        //TODO - Refactor this to use the constant in merge with contants branch
-        setCurrentTimesheetsToDisplay(userTimesheets, date);
-    }
+  const processTimesheetChange = (updated_sheet) => {
+    // Updating the rows of the selected timesheets from our list of timesheets
+    const modifiedTimesheets = userTimesheets.map((entry) => {
+      if (entry.TimesheetID === selectedTimesheet.TimesheetID) {
+        return {
+          ...entry,
+          TableData: updated_sheet.TableData,
+        };
+      }
+      return entry;
+    });
+    setUserTimesheets(modifiedTimesheets);
 
-    const changeTimesheet = (sheet) => {
-        setTimesheet(sheet)
-        setWeeklyComments(getAllActiveCommentsOfType(CommentType.Comment, sheet.WeekNotes))
-        setWeeklyReports(getAllActiveCommentsOfType(CommentType.Report, sheet.WeekNotes))
-    }
-
-
-    const setCurrentTimesheetsToDisplay = (timesheets, currentStartDate: Moment) => {
-        const newCurrentTimesheets = timesheets.filter(sheet => moment.unix(sheet.StartDate).isSame(currentStartDate, 'day'));
-
-        setCurrentTimesheets(newCurrentTimesheets);
-        if (newCurrentTimesheets.length > 0) {
-            changeTimesheet(newCurrentTimesheets[0])
+    //Also need to update our list of currently selected - TODO come up with a way to not need these duplicated lists
+    setCurrentTimesheets(
+      currentTimesheets.map((entry) => {
+        if (entry.TimesheetID === selectedTimesheet.TimesheetID) {
+          return {
+            ...entry,
+            TableData: updated_sheet.TableData,
+          };
         }
-    }
+        return entry;
+      })
+    );
+  };
 
-    const renderWarning = () => {
-        const currentDate = moment();
+  const updateDateRange = (date: Moment) => {
+    setSelectedDate(date);
+    //TODO - Refactor this to use the constant in merge with contants branch
+    setCurrentTimesheetsToDisplay(userTimesheets, date);
+  };
 
-        const dateToCheck = moment(selectedDate);
-        dateToCheck.add(TIMESHEET_DURATION, 'days');
-        if (currentDate.isAfter(dateToCheck, 'days')) {
-            return <Alert status='error'>
-                <AlertIcon/>
-                <AlertTitle>Your timesheet is late!</AlertTitle>
-                <AlertDescription>Please submit this as soon as possible</AlertDescription>
-            </Alert>
-        } else {
-            const dueDuration = dateToCheck.diff(currentDate, 'days');
-            return <Alert status='info'>
-                <AlertIcon/>
-                <AlertTitle>Your timesheet is due in {dueDuration} days!</AlertTitle>
-                <AlertDescription>Remember to press the submit button!</AlertDescription>
-            </Alert>
-        }
+  const changeTimesheet = (sheet) => {
+    setTimesheet(sheet);
+    setWeeklyComments(
+      getAllActiveCommentsOfType(CommentType.Comment, sheet.WeekNotes)
+    );
+    setWeeklyReports(
+      getAllActiveCommentsOfType(CommentType.Report, sheet.WeekNotes)
+    );
+  };
+
+  const setCurrentTimesheetsToDisplay = (
+    timesheets,
+    currentStartDate: Moment
+  ) => {
+    const newCurrentTimesheets = timesheets.filter((sheet) =>
+      moment.unix(sheet.StartDate).isSame(currentStartDate, "day")
+    );
+
+    setCurrentTimesheets(newCurrentTimesheets);
+    if (newCurrentTimesheets.length > 0) {
+      changeTimesheet(newCurrentTimesheets[0]);
     }
+  };
+
+  const renderWarning = () => {
+    const currentDate = moment();
+
+    const dateToCheck = moment(selectedDate);
+    dateToCheck.add(TIMESHEET_DURATION, "days");
+    if (currentDate.isAfter(dateToCheck, "days")) {
+      return (
+        <Alert status="error">
+          <AlertIcon />
+          <AlertTitle>Your timesheet is late!</AlertTitle>
+          <AlertDescription>
+            Please submit this as soon as possible
+          </AlertDescription>
+        </Alert>
+      );
+    } else {
+      const dueDuration = dateToCheck.diff(currentDate, "days");
+      return (
+        <Alert status="info">
+          <AlertIcon />
+          <AlertTitle>Your timesheet is due in {dueDuration} days!</AlertTitle>
+          <AlertDescription>
+            Remember to press the submit button!
+          </AlertDescription>
+        </Alert>
+      );
+    }
+  };
 
   // use this to control whether the timesheet is disabled or not
-  const disabled = false
+  const disabled = false;
 
-
-    return (
-        <>
-            <HStack spacing="120px">
-                <ProfileCard employee={user}/>
-                {(user?.Type === "Supervisor" || user?.Type === "Admin") ?
-                    <>
-                        <SearchEmployeeTimesheet employees={associates} setSelected={setSelectedUser}/>
-                        <IconButton aria-label='Download' icon={<DownloadIcon/>}/>
-                        <IconButton aria-label='Report' icon={<WarningIcon/>}/>
-                    </> : <></>}
-                <DateSelectorCard onDateChange={updateDateRange} date={selectedDate} />
-                
-                
-            </HStack>
-            {useMemo(() => renderWarning(), [selectedDate])}
+  return (
+    <UserContext.Provider value={user}>
+      <>
+        <HStack spacing="120px">
+          <ProfileCard employee={user} />
+          {user?.Type === "Supervisor" || user?.Type === "Admin" ? (
+            <>
+              <SearchEmployeeTimesheet
+                employees={associates}
+                setSelected={setSelectedUser}
+              />
+              <IconButton aria-label="Download" icon={<DownloadIcon />} />
+              <IconButton aria-label="Report" icon={<WarningIcon />} />
+            </>
+          ) : (
+            <></>
+          )}
+          <DateSelectorCard
+            onDateChange={updateDateRange}
+            date={selectedDate}
+          />
+          {selectedTimesheet && (
+            <SubmitCard
+              timesheetId={selectedTimesheet.TimesheetID}
+              associateId={selectedTimesheet.UserID}
+              timesheetStatus={selectedTimesheet.Status}
+              refreshTimesheetCallback={forceRefreshTimesheet}
+            />
+          )}
+        </HStack>
+        {useMemo(() => renderWarning(), [selectedDate])}
         <div>
-            <Tabs>
-                <TabList>
-                    {currentTimesheets.map(
-                        (sheet) => (
-                            <Tab onClick={() => changeTimesheet(sheet)}>{sheet.CompanyID}</Tab>
-                        )
-                    )}
-                </TabList>
-            </Tabs>
+          <Tabs>
+            <TabList>
+              {currentTimesheets.map((sheet) => (
+                <Tab onClick={() => changeTimesheet(sheet)}>
+                  {sheet.CompanyID}
+                </Tab>
+              ))}
+            </TabList>
+          </Tabs>
           <fieldset disabled={disabled}>
-            {selectedTimesheet?.CompanyID === "Total" ?
-                (<AggregationTable Date={selectedDate} timesheets={currentTimesheets}/>)
-                : (<UserContext.Provider value={user}>
-                    <TimeTable columns={TABLE_COLUMNS} timesheet={selectedTimesheet}
-                               onTimesheetChange={processTimesheetChange}/>
-                </UserContext.Provider>)}
-            </fieldset>
-          
-      </div>
-        </>
-    )
+            {selectedTimesheet?.CompanyID === "Total" ? (
+              <AggregationTable
+                Date={selectedDate}
+                timesheets={currentTimesheets}
+              />
+            ) : (
+              <UserContext.Provider value={user}>
+                <TimeTable
+                  columns={TABLE_COLUMNS}
+                  timesheet={selectedTimesheet}
+                  onTimesheetChange={processTimesheetChange}
+                />
+              </UserContext.Provider>
+            )}
+          </fieldset>
+        </div>
+      </>
+    </UserContext.Provider>
+  );
 }

--- a/apps/frontend/src/components/TimeCardPage/types.tsx
+++ b/apps/frontend/src/components/TimeCardPage/types.tsx
@@ -1,44 +1,57 @@
 export enum CellType {
-    Regular = "Time Worked",
-    PTO = "PTO"
-};
+  Regular = "Time Worked",
+  PTO = "PTO",
+}
 
 export enum CellStatus {
-    Active = "Active",
-    Deleted = "Deleted"
+  Active = "Active",
+  Deleted = "Deleted",
 }
 
 export enum CommentType {
-    Comment = "Comment",
-    Report = "Report",
-};
+  Comment = "Comment",
+  Report = "Report",
+}
 
 export enum ReportOptions {
-    Late = "Late Arrival",
-    LeftEarly = "Early Departure",
-    Absent = "No Show"
+  Late = "Late Arrival",
+  LeftEarly = "Early Departure",
+  Absent = "No Show",
 }
 
 export enum Color {
-    Red = "red",
-    Blue = "blue",
-    Green = "green",
-    Gray = "gray"
+  Red = "red",
+  Blue = "blue",
+  Green = "green",
+  Gray = "gray",
 }
 
 export const enum Review_Stages {
-    UNSUBMITTED = "Not-Submitted",
-    EMPLOYEE_SUBMITTED = "Employee Submitted",
-    ADMIN_REVIEW = "Review (Breaktime)",
-    APPROVED = "Approved"
-};
+  UNSUBMITTED = "Not-Submitted",
+  EMPLOYEE_SUBMITTED = "Employee Submitted",
+  ADMIN_REVIEW = "Review (Breaktime)",
+  APPROVED = "Approved",
+}
 
-export const TABLE_COLUMNS = ['Type', 'Date', 'Clock-in', 'Clock-Out', 'Hours', 'Comment'];
+export const TABLE_COLUMNS = [
+  "Type",
+  "Date",
+  "Clock-in",
+  "Clock-Out",
+  "Hours",
+  "Comment",
+];
 
 export enum CardState {
-    Rejected = "Rejected",
-    InReviewEmployer = "In Review - Employer",
-    InReviewBreaktime = "In Review - Breaktime",
-    Completed = "Completed",
-    Unsubmitted = "Unsubmitted"
+  Rejected = "Rejected",
+  InReviewSupervisor = "In Review - Supervisor",
+  InReviewAdmin = "In Review - Admin",
+  AdminFinalized = "Finalized by Admin",
+  Unsubmitted = "Unsubmitted",
+}
+
+export enum UserTypes {
+  Associate = "Associate",
+  Supervisor = "Supervisor",
+  Admin = "Admin",
 }

--- a/apps/frontend/src/components/TimeCardPage/types.tsx
+++ b/apps/frontend/src/components/TimeCardPage/types.tsx
@@ -26,13 +26,6 @@ export enum Color {
   Gray = "gray",
 }
 
-export const enum Review_Stages {
-  UNSUBMITTED = "Not-Submitted",
-  EMPLOYEE_SUBMITTED = "Employee Submitted",
-  ADMIN_REVIEW = "Review (Breaktime)",
-  APPROVED = "Approved",
-}
-
 export const TABLE_COLUMNS = [
   "Type",
   "Date",
@@ -41,14 +34,6 @@ export const TABLE_COLUMNS = [
   "Hours",
   "Comment",
 ];
-
-export enum CardState {
-  Rejected = "Rejected",
-  InReviewSupervisor = "In Review - Supervisor",
-  InReviewAdmin = "In Review - Admin",
-  AdminFinalized = "Finalized by Admin",
-  Unsubmitted = "Unsubmitted",
-}
 
 export enum UserTypes {
   Associate = "Associate",

--- a/apps/frontend/src/schemas/RowSchema.tsx
+++ b/apps/frontend/src/schemas/RowSchema.tsx
@@ -1,55 +1,63 @@
 import { z } from "zod";
-import {CellType, CommentType, Review_Stages, CellStatus, ReportOptions} from '../components/TimeCardPage/types'; 
+import {
+  CellType,
+  CommentType,
+  CellStatus,
+  ReportOptions,
+} from "../components/TimeCardPage/types";
 
 const optionalNumber = z.union([z.undefined(), z.number()]);
 const optionalString = z.union([z.undefined(), z.string()]);
 
-
-
-export const TimeRowEntry = z.union([z.undefined(), z.object({
-    Start: optionalNumber, End: optionalNumber, AuthorID: optionalString
-})]); 
-export type TimeRowEntry = z.infer<typeof TimeRowEntry>
+export const TimeRowEntry = z.union([
+  z.undefined(),
+  z.object({
+    Start: optionalNumber,
+    End: optionalNumber,
+    AuthorID: optionalString,
+  }),
+]);
+export type TimeRowEntry = z.infer<typeof TimeRowEntry>;
 
 export const CommentSchema = z.object({
-    UUID: z.string(), 
-    AuthorID:z.string(), 
-    Type: z.nativeEnum(CommentType), // remove this
-    Timestamp: z.number(), 
-    Content: z.string(), 
-    State: z.nativeEnum(CellStatus),
-}); 
+  UUID: z.string(),
+  AuthorID: z.string(),
+  Type: z.nativeEnum(CommentType), // remove this
+  Timestamp: z.number(),
+  Content: z.string(),
+  State: z.nativeEnum(CellStatus),
+});
 
-export type CommentSchema = z.infer<typeof CommentSchema>
+export type CommentSchema = z.infer<typeof CommentSchema>;
 
 export const ReportSchema = z.object({
-    AuthorID:z.string(), 
-    Timestamp: z.number(),
-    Type: z.nativeEnum(CommentType), 
-    CorrectTime: z.number(),
-    Content: z.nativeEnum(ReportOptions), 
-    Notified: z.string(),
-    Explanation: z.string(),
-    State: z.nativeEnum(CellStatus), 
-}); 
+  AuthorID: z.string(),
+  Timestamp: z.number(),
+  Type: z.nativeEnum(CommentType),
+  CorrectTime: z.number(),
+  Content: z.nativeEnum(ReportOptions),
+  Notified: z.string(),
+  Explanation: z.string(),
+  State: z.nativeEnum(CellStatus),
+});
 
-export type ReportSchema = z.infer<typeof ReportSchema>
+export type ReportSchema = z.infer<typeof ReportSchema>;
 
 export const RowSchema = z.object({
-    Type: z.nativeEnum(CellType), 
-    UUID: z.string(), 
-    Date: z.number(), 
-    Associate: TimeRowEntry, 
-    Supervisor: TimeRowEntry, 
-    Admin: TimeRowEntry, 
-    Comment: z.union([z.undefined(), z.array(CommentSchema || ReportSchema)])
-}); 
-export type RowSchema = z.infer<typeof RowSchema>
+  Type: z.nativeEnum(CellType),
+  UUID: z.string(),
+  Date: z.number(),
+  Associate: TimeRowEntry,
+  Supervisor: TimeRowEntry,
+  Admin: TimeRowEntry,
+  Comment: z.union([z.undefined(), z.array(CommentSchema || ReportSchema)]),
+});
+export type RowSchema = z.infer<typeof RowSchema>;
 
 export const ScheduledRowSchema = z.object({
-    UUID: z.string(), 
-    Date: z.number(), 
-    Entry: TimeRowEntry
-}); 
+  UUID: z.string(),
+  Date: z.number(),
+  Entry: TimeRowEntry,
+});
 
-export type ScheduledRowSchema  = z.infer<typeof ScheduledRowSchema>
+export type ScheduledRowSchema = z.infer<typeof ScheduledRowSchema>;

--- a/apps/frontend/src/schemas/StatusSchema.tsx
+++ b/apps/frontend/src/schemas/StatusSchema.tsx
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+// The status is either undefined, for not being at that stage yet, or
+// contains the date and author of approving this submission
+export const StatusEntryType = z.union([
+  z.object({
+    Date: z.number(),
+    AuthorID: z.string(),
+  }),
+  z.undefined(),
+]);
+
+// Status type contains the four stages of the pipeline we have defined
+export const StatusType = z.object({
+  HoursSubmitted: StatusEntryType,
+  HoursReviewed: StatusEntryType,
+  Finalized: StatusEntryType,
+});
+
+export type StatusEntryType = z.infer<typeof StatusEntryType>;
+export type StatusType = z.infer<typeof StatusType>;

--- a/apps/frontend/src/schemas/TimesheetSchema.tsx
+++ b/apps/frontend/src/schemas/TimesheetSchema.tsx
@@ -1,32 +1,22 @@
 import { z } from "zod";
-import { RowSchema, ScheduledRowSchema, CommentSchema } from './RowSchema';
-
-// The status is either undefined, for not being at that stage yet, or 
-// contains the date and author of approving this submission 
-export const StatusEntryType = z.union(
-  [z.object({
-    Date: z.number(),
-    AuthorID: z.string()
-  }),
-  z.undefined()]);
-
-// Status type contains the four stages of the pipeline we have defined
-export const StatusType = z.object({
-  HoursSubmitted: StatusEntryType,
-  HoursReviewed: StatusEntryType,
-  ScheduleSubmitted: StatusEntryType,
-  Finalized: StatusEntryType
-});
+import { RowSchema, ScheduledRowSchema, CommentSchema } from "./RowSchema";
+import { StatusType } from "./StatusSchema";
 
 export const TimeSheetSchema = z.object({
-  TimesheetID: z.number(),  
-  UserID: z.string(), 
+  TimesheetID: z.number(),
+  UserID: z.string(),
   StartDate: z.number(),
-  Status: StatusType, 
-  CompanyID: z.string(), 
-  TableData: z.array(RowSchema), 
+  Status: StatusType,
+  CompanyID: z.string(),
+  TableData: z.array(RowSchema),
   ScheduleTableData: z.union([z.undefined(), z.array(ScheduledRowSchema)]),
-  WeekNotes: z.union([z.undefined(), z.array(CommentSchema)]), 
-}); 
+  WeekNotes: z.union([z.undefined(), z.array(CommentSchema)]),
+});
 
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>;
+
+export enum TimesheetStatus {
+  HOURS_SUBMITTED = "HoursSubmitted",
+  HOURS_REVIEWED = "HoursReviewed",
+  FINALIZED = "Finalized",
+}

--- a/apps/frontend/src/schemas/TimesheetSchema.tsx
+++ b/apps/frontend/src/schemas/TimesheetSchema.tsx
@@ -16,6 +16,7 @@ export const TimeSheetSchema = z.object({
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>;
 
 export enum TimesheetStatus {
+  UNSUBMITTED = "Unsubmitted",
   HOURS_SUBMITTED = "HoursSubmitted",
   HOURS_REVIEWED = "HoursReviewed",
   FINALIZED = "Finalized",

--- a/apps/frontend/src/schemas/UserSchema.tsx
+++ b/apps/frontend/src/schemas/UserSchema.tsx
@@ -1,10 +1,11 @@
 import { z } from "zod";
+import { UserTypes } from "src/components/TimeCardPage/types";
 
 export const UserSchema = z.object({
   UserID: z.string(),
   FirstName: z.string(),
   LastName: z.string(),
-  Type: z.enum(["Associate", "Supervisor", "Admin"]),
+  Type: z.enum([UserTypes.Associate, UserTypes.Supervisor, UserTypes.Admin]),
   Picture: z.string().optional(),
 });
 

--- a/apps/frontend/src/schemas/backend/Timesheet.ts
+++ b/apps/frontend/src/schemas/backend/Timesheet.ts
@@ -43,7 +43,11 @@ export const TimeEntrySchema = z.object({
   AuthorUUID: z.string(),
 })
 
-
+/* 
+  Supported type of cells for each row in a timesheet 
+    @REGULAR - a regular cell
+    @PTO - Cell signifying paid time off (PTO) 
+*/
 export enum CellType {
   REGULAR = "Time Worked", 
   PTO = "PTO"
@@ -72,14 +76,18 @@ export const StatusEntryType = z.union(
   }), 
   z.undefined()]); 
 
-// Status type contains the four stages of the pipeline we have defined 
-export const TimesheetStatus = z.object({
+// Status type contains the three stages of the pipeline we have defined 
+export const TimesheetStatusSchema = z.object({
   HoursSubmitted: StatusEntryType, 
   HoursReviewed: StatusEntryType,
-  ScheduleSubmitted: StatusEntryType, 
   Finalized: StatusEntryType 
 });
 
+export enum TimesheetStatusType {
+  HOURS_SUBMITTED="HoursSubmitted",
+  HOURS_REVIEWED="HoursReviewed",
+  FINALIZED="Finalized"
+}
 
 
 /**
@@ -89,14 +97,14 @@ export const TimeSheetSchema = z.object({
   TimesheetID: z.number(), 
   UserID: z.string(), 
   StartDate: z.number(),
-  Status: TimesheetStatus,
+  Status: TimesheetStatusSchema,
   CompanyID: z.string(), 
   HoursData: z.array(TimesheetEntrySchema).default([]), 
   ScheduleData: z.array(ScheduleEntrySchema).default([]),
   WeekNotes: z.array(NoteSchema).default([]),
 })
 
-export type TimesheetStatus = z.infer<typeof TimesheetStatus>
+export type TimesheetStatus = z.infer<typeof TimesheetStatusSchema>
 export type TimeEntrySchema = z.infer<typeof TimeEntrySchema> 
 export type ScheduleEntrySchema = z.infer<typeof ScheduleEntrySchema> 
 export type NoteSchema = z.infer<typeof NoteSchema>

--- a/apps/frontend/src/schemas/backend/UpdateTimesheet.ts
+++ b/apps/frontend/src/schemas/backend/UpdateTimesheet.ts
@@ -12,7 +12,16 @@ import * as dbtypes from './Timesheet'
 
 */
 
-// Currently supported timesheet operations 
+/*
+    The supported timesheet operations currently supported. 
+        Most operations relate to items that are inside the timesheet, whether it is the rows of the timesheet, the comments someone left 
+        on it for example. 
+    INSERT - Inserting an item into the timesheet 
+    UPDATE - Updating a specific item in the timesheet 
+    DELETE - Deleting a speciic item in the timesheet 
+    STATUS_CHANGE - When the timesheet has been submitted / should be advanced to the next stage 
+    CREATE-TIMESHEET - Operation for creating a timesheet, if it would be useful to have in the future. 
+*/
 export const enum TimesheetOperations {
     INSERT = "INSERT", 
     UPDATE = "UPDATE", 
@@ -21,8 +30,12 @@ export const enum TimesheetOperations {
     CREATE_TIMESHEET = "CREATE_TIMESHEET"
 } 
 
-
-
+/*
+    The available types of items that are currently supported in the timesheet that list operations can be performed on. 
+        TABLEDATA - the rows of the timesheet- basically their worked schedule  
+        SCHEDULEDATA - the expected schedule they should have worked 
+        WEEKNOTES - the comments left by an employer for that week 
+*/
 export const enum TimesheetListItems {
     TABLEDATA = "TABLEDATA", 
     SCHEDULEDATA = "SCHEDULEDATA", 
@@ -31,23 +44,34 @@ export const enum TimesheetListItems {
 
 const availableListTypes = z.enum([TimesheetListItems.TABLEDATA, TimesheetListItems.SCHEDULEDATA, TimesheetListItems.WEEKNOTES])
 
+/* 
+    The schema for a delete request 
+        @Type: The type of the item this delete request is processing - see available types in TimesheetListItems 
+        @Id: The id of the item we are deleting - to know what to remove 
+*/
 export const DeleteRequest = z.object({
     Type: availableListTypes, 
     Id: z.string() 
 })
 export type DeleteRequest = z.infer<typeof DeleteRequest> 
 
+/*
+    The schema for an insert request for an item 
+        @Type: The type of the item that we are inserting, to know what we should be adding this item to
+        @Item: The item we are actually inserting, should be the actual item itself. 
+*/
 export const InsertRequest = z.object({
     Type: availableListTypes, 
     Item: z.union([RowSchema, CommentSchema, ScheduledRowSchema, dbtypes.TimesheetEntrySchema]), 
 }) 
 export type InsertRequest = z.infer<typeof InsertRequest> 
+
 /*
     Schema for updating an item from the three possible list of items in the timesheet 
-    Type: The field of the timesheet we are updating from the three supported 
-    Id: the id of the entry we are updating - correlates to that row / entry in the list of items 
-    Attribute: The specific attribute of the object we are updating 
-    Data: The payload we are updating this attribute to be - can be a wide range of things currently 
+        @Type: The field of the timesheet we are updating from the three supported 
+        @Id: the id of the entry we are updating - correlates to that row / entry in the list of items 
+        @Attribute: The specific attribute of the object we are updating 
+        @Data: The payload we are updating this attribute to be - can be a wide range of things currently 
 */
 export const UpdateRequest = z.object({
     Type: availableListTypes, 
@@ -57,8 +81,28 @@ export const UpdateRequest = z.object({
 })
 export type UpdateRequest = z.infer<typeof UpdateRequest>
 
+/*
+    Schema for changing the status of a timesheet 
+        @TimesheetId: The id of the timesheet we are updating 
+        @AssociateId: The id of the associate whose timesheet is being submitted
+        @authorId: 
+        @dateSubmitted: The date the timesheet was submitted
+        @statusType: 
+*/
+export const StatusChangeRequest = z.object({
+    TimesheetId: z.number(),
+    AssociateId: z.string(),
+    authorId: z.string(),
+    dateSubmitted: z.number(),
+    statusType: z.enum([dbtypes.TimesheetStatusType.HOURS_SUBMITTED, dbtypes.TimesheetStatusType.HOURS_REVIEWED, dbtypes.TimesheetStatusType.FINALIZED]),
+})
+export type StatusChangeRequest = z.infer<typeof StatusChangeRequest>
 
-// The main request body that is used to determine what we should be updating in a request 
+/* The main request body that is used to determine what we should be updating in a request 
+    @TimesheetID: The id of the timesheet we are updating 
+    @Operation: The type of operation we are performing on this timesheet 
+    @Payload: The contents to be used in the operation for updating this. 
+*/
 export const TimesheetUpdateRequest = z.object({
     TimesheetID: z.number(), 
     Operation: z.enum([


### PR DESCRIPTION
ℹ️ Issue Closes #68

📝 Description 

- Added styling for the Submit Card on the Timesheet page
- Added in auto-reload of the current timesheet data upon submission
- Made the submit card read in live data from the backend to base state and displayed info off of
- Implemented global user context to be used, and set the current user data based off of the live logged in user data rather than dummy data

✔️ Testing 
Ran on both Supervisor and Associate view and submitted separately, making sure the submit card was updated between them. Made sure data persisted on page reload.

![image](https://github.com/Code-4-Community/breaktime/assets/32255130/09028fd0-af47-423d-9874-04cefb6eda4e)
![image](https://github.com/Code-4-Community/breaktime/assets/32255130/ff6d82ea-f9ab-4d2d-bb09-3522cc91a0a3)
![image](https://github.com/Code-4-Community/breaktime/assets/32255130/98f679a4-fb7d-4a28-8002-48f17ba14a3a)
![image](https://github.com/Code-4-Community/breaktime/assets/32255130/705c74ec-ca25-4cd6-b99d-52512b7d493e)


Further todo:

Switch the userIds displayed on the submit card to be the names of the users instead (or even better, the profile card for them)
Bug where when you switch to a different week that has no timesheet populated, the submit card doesn't change
